### PR TITLE
🐞 fix(port_cmsis-os2): 修复返回值

### DIFF
--- a/port/cmsis-os2/xf_osal_event.c
+++ b/port/cmsis-os2/xf_osal_event.c
@@ -34,14 +34,18 @@ xf_osal_event_t xf_osal_event_create(const xf_osal_event_attr_t *attr)
 
 xf_err_t xf_osal_event_set(xf_osal_event_t event, uint32_t flags)
 {
-    osEventFlagsSet((osEventFlagsId_t)event, flags);
-    return XF_OK;
+    uint32_t status = osEventFlagsSet((osEventFlagsId_t)event, flags);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 }
 
 xf_err_t xf_osal_event_clear(xf_osal_event_t event, uint32_t flags)
 {
-    osEventFlagsClear((osEventFlagsId_t)event, flags);
-    return XF_OK;
+    uint32_t status = osEventFlagsClear((osEventFlagsId_t)event, flags);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 }
 
 uint32_t xf_osal_event_get(xf_osal_event_t event)
@@ -51,14 +55,18 @@ uint32_t xf_osal_event_get(xf_osal_event_t event)
 
 xf_err_t xf_osal_event_wait(xf_osal_event_t event, uint32_t flags, uint32_t options, uint32_t timeout)
 {
-    osEventFlagsWait((osEventFlagsId_t)event, flags, options, timeout);
-    return XF_OK;
+    uint32_t status = osEventFlagsWait((osEventFlagsId_t)event, flags, options, timeout);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 }
 
 xf_err_t xf_osal_event_delete(xf_osal_event_t event)
 {
-    osEventFlagsDelete((osEventFlagsId_t)event);
-    return XF_OK;
+    uint32_t status = osEventFlagsDelete((osEventFlagsId_t)event);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 }
 
 /* ==================== [Static Functions] ================================== */

--- a/port/cmsis-os2/xf_osal_thread.c
+++ b/port/cmsis-os2/xf_osal_thread.c
@@ -130,8 +130,10 @@ uint32_t xf_osal_thread_get_active_count(xf_osal_thread_t *thread_array, uint32_
 xf_err_t xf_osal_thread_notify_set(xf_osal_thread_t thread, uint32_t notify)
 {
 #if XF_CMSIS_THREAD_NOTIFY_IS_ENABLE
-    osThreadFlagsSet((osThreadId_t)thread, (uint32_t)notify);
-    return XF_OK;
+    uint32_t status = osThreadFlagsSet((osThreadId_t)thread, (uint32_t)notify);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 #else
     return XF_ERR_NOT_SUPPORTED;
 #endif
@@ -140,8 +142,10 @@ xf_err_t xf_osal_thread_notify_set(xf_osal_thread_t thread, uint32_t notify)
 xf_err_t xf_osal_thread_notify_clear(uint32_t notify)
 {
 #if XF_CMSIS_THREAD_NOTIFY_IS_ENABLE
-    osThreadFlagsClear((uint32_t)notify);
-    return XF_OK;
+    uint32_t status = osThreadFlagsClear((uint32_t)notify);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 #else
     return XF_ERR_NOT_SUPPORTED;
 #endif
@@ -159,8 +163,10 @@ uint32_t xf_osal_thread_notify_get(void)
 xf_err_t xf_osal_thread_notify_wait(uint32_t notify, uint32_t options, uint32_t timeout)
 {
 #if XF_CMSIS_THREAD_NOTIFY_IS_ENABLE
-    osThreadFlagsWait(notify, options, timeout);
-    return XF_OK;
+    uint32_t status = osThreadFlagsWait(notify, options, timeout);
+    xf_err_t err = (status & osFlagsError) ? (transform_to_xf_err(status)) : (XF_OK);
+
+    return err;
 #else
     return XF_ERR_NOT_SUPPORTED;
 #endif


### PR DESCRIPTION
close #5

没有添加 `options |= XF_OSAL_NO_CLEAR;`，用户如果需要知道哪些标志未置位引起的超时需自行设置options，发生超时错误后自行`xf_osal_event_get()`或`xf_osal_thread_notify_get()`。